### PR TITLE
vertical alignment fix

### DIFF
--- a/src/containers/Home.css
+++ b/src/containers/Home.css
@@ -47,7 +47,6 @@ a {
 .main {
   display: flex;
   justify-content: center;
-  align-items: center;
 }
 
 section {


### PR DESCRIPTION
Fixing a small bug: the site title "This Week In React" is hidden when the screen height is insufficient, and it is not possible to scroll up. This was caused by .main being set to "align-items: center;". Removing this rule aligns the content at the top of the screen rather than the center.